### PR TITLE
Multiple Data Set Concatenation

### DIFF
--- a/genomics_benchmarks/config/benchmark.conf.default
+++ b/genomics_benchmarks/config/benchmark.conf.default
@@ -103,6 +103,9 @@ benchmark_number_runs = 5
 benchmark_data_input = vcf
 
 # Specifies which dataset to use for the benchmarking process.
+# If a value * is specified, the benchmark will concatenate all data in the ./data/zarr/ directory.
+#   - Note: In order to use concatenation, all data sets must have the same number of samples to align properly.
+#   - Note: Concatenation (*) can only be used when benchmark_data_input is set to zarr.
 benchmark_dataset =
 
 # Specifies the number of variants to include from the dataset input for benchmarking.

--- a/genomics_benchmarks/core.py
+++ b/genomics_benchmarks/core.py
@@ -268,7 +268,7 @@ class Benchmark:
 
         # Create the genotype array and benchmark its execution time
         self.benchmark_profiler.start_benchmark(operation_name="Create Genotype Array")
-        gt = data_service.get_genotype_data_concat(callsets=callsets, genotype_array_type=genotype_array_type)
+        gt = data_service.get_genotype_array_concat(callsets=callsets, genotype_array_type=genotype_array_type)
         self.benchmark_profiler.end_benchmark()
 
         # If the number of variants or samples were specified, limit the genotype data returned

--- a/genomics_benchmarks/data_service.py
+++ b/genomics_benchmarks/data_service.py
@@ -401,6 +401,7 @@ def get_genotype_array_concat(callsets, genotype_array_type=config.GENOTYPE_ARRA
     if genotype_array_type == config.GENOTYPE_ARRAY_DASK:
         combined_gt = da.concatenate(gtz_list, axis=0)
         chunk_size = gtz_list[0].chunks  # Get chunk size of first callset
+        print('[DEBUG] Chunk Size: {}'.format(chunk_size))
         combined_gt = combined_gt.rechunk(chunk_size)  # Rechunk all data so that data can be split up across nodes
         combined_gt = allel.GenotypeDaskArray(combined_gt)
     elif genotype_array_type == config.GENOTYPE_ARRAY_CHUNKED:

--- a/genomics_benchmarks/data_service.py
+++ b/genomics_benchmarks/data_service.py
@@ -401,7 +401,6 @@ def get_genotype_array_concat(callsets, genotype_array_type=config.GENOTYPE_ARRA
     if genotype_array_type == config.GENOTYPE_ARRAY_DASK:
         combined_gt = da.concatenate(gtz_list, axis=0)
         chunk_size = gtz_list[0].chunks  # Get chunk size of first callset
-        print('[DEBUG] Chunk Size: {}'.format(chunk_size))
         combined_gt = combined_gt.rechunk(chunk_size)  # Rechunk all data so that data can be split up across nodes
         combined_gt = allel.GenotypeDaskArray(combined_gt)
     elif genotype_array_type == config.GENOTYPE_ARRAY_CHUNKED:

--- a/genomics_benchmarks/data_service.py
+++ b/genomics_benchmarks/data_service.py
@@ -394,9 +394,13 @@ def get_genotype_array_concat(callsets, genotype_array_type=config.GENOTYPE_ARRA
         return get_genotype_array(callset=callset, genotype_array_type=genotype_array_type)
 
     gt_list = []
+
+    # Get genotype data for each callset
     for callset in callsets:
         gt = get_callset_genotype_data(callset)
-        gt = da.from_array(gt, chunks=gt.chunks)
+        if genotype_array_type == config.GENOTYPE_ARRAY_DASK:
+            # Encapsulate underlying zarr array with a chunked dask array
+            gt = da.from_array(gt, chunks=gt.chunks)
         gt_list.append(gt)
 
     if genotype_array_type == config.GENOTYPE_ARRAY_DASK:

--- a/genomics_benchmarks/data_service.py
+++ b/genomics_benchmarks/data_service.py
@@ -393,20 +393,19 @@ def get_genotype_array_concat(callsets, genotype_array_type=config.GENOTYPE_ARRA
         callset = callsets[0]
         return get_genotype_array(callset=callset, genotype_array_type=genotype_array_type)
 
-    gtz_list = []
+    gt_list = []
     for callset in callsets:
-        gtz = get_callset_genotype_data(callset)
-        gtz_list.append(gtz)
+        gt = get_callset_genotype_data(callset)
+        gt = da.from_array(gt, chunks=gt.chunks)
+        gt_list.append(gt)
 
     if genotype_array_type == config.GENOTYPE_ARRAY_DASK:
-        combined_gt = da.concatenate(gtz_list, axis=0)
-        chunk_size = gtz_list[0].chunks  # Get chunk size of first callset
-        combined_gt = combined_gt.rechunk(chunk_size)  # Rechunk all data so that data can be split up across nodes
+        combined_gt = da.concatenate(gt_list, axis=0)
         combined_gt = allel.GenotypeDaskArray(combined_gt)
     elif genotype_array_type == config.GENOTYPE_ARRAY_CHUNKED:
-        combined_gt = allel.GenotypeChunkedArray(np.concatenate(gtz_list, axis=0))
+        combined_gt = allel.GenotypeChunkedArray(np.concatenate(gt_list, axis=0))
     elif genotype_array_type == config.GENOTYPE_ARRAY_NORMAL:
-        combined_gt = allel.GenotypeArray(np.concatenate(gtz_list, axis=0))
+        combined_gt = allel.GenotypeArray(np.concatenate(gt_list, axis=0))
     else:
         raise ValueError('Error: Invalid option specified for genotype_array_type.')
 

--- a/genomics_benchmarks/data_service.py
+++ b/genomics_benchmarks/data_service.py
@@ -368,30 +368,7 @@ def convert_to_zarr(input_vcf_path, output_zarr_path, conversion_config, benchma
             benchmark_profiler.end_benchmark()
 
 
-def get_genotype_data_concat(callsets, genotype_array_type=config.GENOTYPE_ARRAY_DASK):
-    if len(callsets) == 1:
-        # Only one callset provided. No need for concatenation
-        callset = callsets[0]
-        return get_genotype_data(callset=callset, genotype_array_type=genotype_array_type)
-
-    gt_list = []
-    for callset in callsets:
-        gt = get_genotype_data(callset, genotype_array_type)
-        gt_list.append(gt)
-
-    if genotype_array_type == config.GENOTYPE_ARRAY_DASK:
-        combined_gt = allel.GenotypeDaskArray(da.concatenate(gt_list, axis=0))
-    elif genotype_array_type == config.GENOTYPE_ARRAY_CHUNKED:
-        combined_gt = allel.GenotypeChunkedArray(np.concatenate(gt_list, axis=0))
-    elif genotype_array_type == config.GENOTYPE_ARRAY_NORMAL:
-        combined_gt = allel.GenotypeArray(np.concatenate(gt_list, axis=0))
-    else:
-        raise ValueError('Error: Invalid option specified for genotype_array_type.')
-
-    return combined_gt
-
-
-def get_genotype_data(callset, genotype_array_type=config.GENOTYPE_ARRAY_DASK):
+def get_callset_genotype_data(callset):
     genotype_ref_name = ''
 
     # Ensure 'calldata' is within the callset
@@ -407,6 +384,37 @@ def get_genotype_data(callset, genotype_array_type=config.GENOTYPE_ARRAY_DASK):
         return None
 
     gtz = callset['calldata'][genotype_ref_name]
+    return gtz
+
+
+def get_genotype_array_concat(callsets, genotype_array_type=config.GENOTYPE_ARRAY_DASK):
+    if len(callsets) == 1:
+        # Only one callset provided. No need for concatenation
+        callset = callsets[0]
+        return get_genotype_array(callset=callset, genotype_array_type=genotype_array_type)
+
+    gtz_list = []
+    for callset in callsets:
+        gtz = get_callset_genotype_data(callset)
+        gtz_list.append(gtz)
+
+    if genotype_array_type == config.GENOTYPE_ARRAY_DASK:
+        combined_gt = da.concatenate(gtz_list, axis=0)
+        chunk_size = gtz_list[0].chunks  # Get chunk size of first callset
+        combined_gt = combined_gt.rechunk(chunk_size)  # Rechunk all data so that data can be split up across nodes
+        combined_gt = allel.GenotypeDaskArray(combined_gt)
+    elif genotype_array_type == config.GENOTYPE_ARRAY_CHUNKED:
+        combined_gt = allel.GenotypeChunkedArray(np.concatenate(gtz_list, axis=0))
+    elif genotype_array_type == config.GENOTYPE_ARRAY_NORMAL:
+        combined_gt = allel.GenotypeArray(np.concatenate(gtz_list, axis=0))
+    else:
+        raise ValueError('Error: Invalid option specified for genotype_array_type.')
+
+    return combined_gt
+
+
+def get_genotype_array(callset, genotype_array_type=config.GENOTYPE_ARRAY_DASK):
+    gtz = get_callset_genotype_data(callset)
 
     if genotype_array_type == config.GENOTYPE_ARRAY_NORMAL:
         return allel.GenotypeArray(gtz)


### PR DESCRIPTION
This PR adds the ability to concatenate multiple Zarr data sets when benchmarking and when using Dask arrays. This is useful for combining multiple chromosome data sets into a single data set, for example.

To use this feature, specify a value of (*) for benchmark_dataset in the configuration file. This will cause the benchmark program to concatenate all data sets in the ./data/zarr directory.