### PR TITLE
PCA Benchmark: Dask Array Improvements & Allow All Variants to be Included

### DIFF
--- a/genomics_benchmarks/config.py
+++ b/genomics_benchmarks/config.py
@@ -334,9 +334,12 @@ class BenchmarkConfigurationRepresentation:
                     pca_subset_size_str = runtime_config.benchmark["pca_subset_size"]
                     if isint(pca_subset_size_str) and (int(pca_subset_size_str) > 0):
                         self.pca_subset_size = int(pca_subset_size_str)
+                    elif isint(pca_subset_size_str) and (int(pca_subset_size_str) == -1):
+                        self.pca_subset_size = int(pca_subset_size_str)
                     else:
                         raise ValueError("Invalid value for pca_subset_size in configuration.\n"
-                                         "pca_subset_size must be a valid integer greater than 0.")
+                                         "pca_subset_size must be a valid integer greater than 0.\n"
+                                         "Additionally, a value of -1 can be used to include all samples.")
                 if "pca_ld_enabled" in runtime_config.benchmark:
                     self.pca_ld_enabled = config_str_to_bool(runtime_config.benchmark["pca_ld_enabled"])
                 if "pca_ld_pruning_number_iterations" in runtime_config.benchmark:

--- a/genomics_benchmarks/config/benchmark.conf.default
+++ b/genomics_benchmarks/config/benchmark.conf.default
@@ -119,14 +119,14 @@ benchmark_num_samples = -1
 benchmark_aggregations = True
 
 # Enables Principal Component Analysis (PCA) as part of the benchmarking process.
-benchmark_pca = False
+benchmark_pca = True
 
 # Specifies the type of data array to use when loading the genotype data for benchmarking.
 # Possible Values:
 #   - Normal:   0
 #   - Dask:     1
 #   - Chunked:  2
-genotype_array_type = 2
+genotype_array_type = 1
 
 # [PCA Benchmark] Specifies the number of principal components to keep when performing PCA analysis.
 pca_number_components = 10
@@ -140,7 +140,8 @@ pca_data_scaler = 1
 
 # [PCA Benchmark] Sets the number of SNPs to use as a subset of the data set.
 # If the size of the data set is smaller than pca_subset_size, that will be used instead.
-pca_subset_size = 100000
+# Additionally, a value of -1 can be passed to include everything (no random subset will be taken).
+pca_subset_size = -1
 
 # [PCA Benchmark: Linkage Disequilibrium] Specifies whether to enable or disable LD pruning operation.
 # Note: The LD pruning implementation is not parallelized and may not scale well when running on multi-node systems.


### PR DESCRIPTION
This PR:
- Adds improvements to PCA benchmark when using Dask arrays (no longer uses numpy functions on Dask arrays)
- Allows all data to be included in PCA instead of having to select n random entries (if desired)
- Enable PCA benchmark by default (previously disabled)
- Change default genotype array to Dask (previously Chunked array)